### PR TITLE
Change stop command in init script to avoid orphan process

### DIFF
--- a/templates/etc/init.d/nomad.Debian.j2
+++ b/templates/etc/init.d/nomad.Debian.j2
@@ -86,7 +86,7 @@ do_start()
 do_stop()
 {
     # first try doing this gracefully
-    pkill -f $DAEMON
+    pkill $NAME
     # Return
     #   0 if daemon has been stopped
     #   1 if daemon was already stopped

--- a/templates/etc/init.d/nomad.RedHat.j2
+++ b/templates/etc/init.d/nomad.RedHat.j2
@@ -26,6 +26,7 @@
 prog="nomad"
 user="{{nomad_user}}"
 exec="{{nomad_bin}}"
+exec_child="{{nomad_dest}}"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
 logfile="/var/log/$prog"
@@ -70,10 +71,10 @@ stop() {
     echo -n $"Shutting down $prog: "
     ## graceful shutdown with SIGINT
     #killproc -p $pidfile $exec -INT
-    pkill $prog
+    pkill -f $exec && pkill -f $exec_child
     RETVAL=$?
     echo
-    [ $RETVAL -eq 0 ] && rm -f $lockfile
+    [ $RETVAL -eq 0 ] && rm -f $lockfile && rm -f $pidfile
     return $RETVAL
 }
 

--- a/templates/etc/init.d/nomad.RedHat.j2
+++ b/templates/etc/init.d/nomad.RedHat.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Nomad        Manage the Nomad agent
-#       
+#
 # chkconfig:   2345 95 05
 # description: Nomad is a tool for service discovery and configuration
 # processname: nomad
@@ -39,7 +39,7 @@ export GOMAXPROCS=${GOMAXPROCS:-2}
 
 start() {
     [ -x $exec ] || exit 5
-    
+
     [ -d $confdir ] || exit 6
 
     umask 077
@@ -48,7 +48,7 @@ start() {
     chown $user:$user $logfile $pidfile
 
     echo -n $"Starting $prog: "
-    
+
     ## holy shell shenanigans, batman!
     ## daemon can't be backgrounded.  we need the pid of the spawned process,
     ## which is actually done via runuser thanks to --user.  you can't do "cmd
@@ -57,12 +57,12 @@ start() {
         --pidfile=$pidfile \
         --user=${user} \
         " { $exec ${DAEMON_ARGS} ${NOMAD_OPTS} &>> $logfile & } ; echo \$! >| $pidfile "
-    
+
     RETVAL=$?
     echo
-    
+
     [ $RETVAL -eq 0 ] && touch $lockfile
-    
+
     return $RETVAL
 }
 
@@ -70,7 +70,7 @@ stop() {
     echo -n $"Shutting down $prog: "
     ## graceful shutdown with SIGINT
     #killproc -p $pidfile $exec -INT
-    pkill -f $exec
+    pkill $prog
     RETVAL=$?
     echo
     [ $RETVAL -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
The  current method of `pkill -f $exec` is leaving orphan child process running which generates misleading behaviors after a nomad shutdown